### PR TITLE
saved duration needs input of seconds, not ms

### DIFF
--- a/src/store/setup.ts
+++ b/src/store/setup.ts
@@ -181,7 +181,7 @@ function createTauriFileAdapter<S>(tauriStore: Store) {
             const allSeconds = parseAbsoluteToLocal(finishedAt).compare(
               parseAbsoluteToLocal(fromTime)
             );
-            const duration = getDuration(allSeconds);
+            const duration = getDuration(allSeconds / 1000);
             return `|${duration.hours
               .toString()
               .padStart(2, "0")}:${duration.minutes


### PR DESCRIPTION
## Motivation

The content saved in the file with the relative timestamp required an input of seconds, not ms, so it was 1000x too large. Fixed!
